### PR TITLE
Use Path::Tiny::path instead of path to prevent calling the wrong function

### DIFF
--- a/lib/Dancer2/Plugin/OpenAPIRoutes.pm
+++ b/lib/Dancer2/Plugin/OpenAPIRoutes.pm
@@ -137,7 +137,7 @@ sub load_schema {
     my $file = File::Spec->catfile($config->{app}->location, $config->{schema});
     if ($config->{schema} =~ /\.json/i) {
         require Path::Tiny;
-        $schema = JSON::from_json(path($file)->slurp_utf8);
+        $schema = JSON::from_json(Path::Tiny::path($file)->slurp_utf8);
     } elsif ($config->{schema} =~ /\.yaml/i) {
         $schema = YAML::XS::LoadFile $file;
     }


### PR DESCRIPTION
Fixes the following crash:

```
Error while loading /home/racke/sympa-community/sympa-rest-api/bin/app.psgi: Can't locate object method
"app" via package "/home/racke/sympa-community/sympa-rest-api/public/sympa-api.json" (perhaps you
forgot to load "/home/racke/sympa-community/sympa-rest-api/public/sympa-api.json"?) at /home/racke/perl5
/perlbrew/perls/perl-5.24.0/lib/site_perl/5.24.1/Dancer2/Plugin.pm line 542.
```

The error message is quite confusing, but somehow the wrong _path_ function was used.